### PR TITLE
Add the projects cli argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,17 @@ Creates a new migration file at `/integrations/contentful/migrations` with the `
 npx etch-contentful-cli migration:run
 ```
 
-Runs all migrations that haven't already been run
+Runs all migrations that haven't already been run.
+
+Accepts an optional  `--projects <projectOne,projectTwo>` argument which allows migrations to be filtered.
+
+Projects can be set per migration, by exporting a projects array:
+
+```javascript
+export const projects = ['projectOne', 'projectTwo'];
+```
+
+If no projects argument is provided, all migrations will run.
 
 #### Generate types
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ npx etch-contentful-cli migration:run
 
 Runs all migrations that haven't already been run.
 
-Accepts an optional  `--projects <projectOne,projectTwo>` argument which allows migrations to be filtered.
+The `migration:run` command accepts an optional projects argument `--projects <projectOne,projectTwo>`.
 
-Projects can be set per migration, by exporting a projects array:
+This will filter out any migrations that don't export a matching project name as part of its `module.exports.projects` array:
 
 ```javascript
-export const projects = ['projectOne', 'projectTwo'];
+module.exports.projects = ['projectOne', 'projectTwo'];
 ```
 
 If no projects argument is provided, all migrations will run.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,12 +17,16 @@ program
 program
   .command('migration:new')
   .description('Create a new migration file')
-  .argument('<migrationName>', 'Name of the migration (Eg.: "Add article"): ')
+  .argument('<migrationName>', 'Name of the migration (Eg.: "Add article")')
   .action(createMigration);
 
 program
   .command('migration:run')
   .description('Run all migrations that haven\'t already been run')
+  .option(
+    '-p, --projects <projectOne,projectTwo>',
+    'Project names (separated by commas) to run this migration for'
+  )
   .action(runMigration);
 
 program

--- a/src/cli/create-migration.ts
+++ b/src/cli/create-migration.ts
@@ -4,8 +4,7 @@ import kebabCase from 'lodash/kebabCase';
 import { MIGRATION_DIR } from './config';
 
 const migrationTemplate =
-`/* eslint-disable @typescript-eslint/ban-ts-comment */
-import type { MigrationFunction, validator } from '@etchteam/contentful';
+`import type { MigrationFunction, validator } from '@etchteam/contentful';
 
 const migrate: MigrationFunction = (migration) => {
   /*
@@ -59,15 +58,16 @@ const migrate: MigrationFunction = (migration) => {
   */
 };
 
-// @ts-ignore
-export = migrate;
+module.exports = migrate; // This has to be a CJS compatible export
+
+// Optionally set the projects this migration should run on
+// Migrations can be filtered using the 'projects' cli option (eg. migration:run --projects projectOne,projectTwo)
+// module.exports.projects = ['projectOne'];
 `;
 
 const createMigration = (migrationName: string) => {
   const migrationFiles = fs.readdirSync(MIGRATION_DIR);
-  const lastMigration = migrationFiles[migrationFiles.length - 1];
-  const newMigrationNumber = parseInt(lastMigration.split('-')[0]) + 1;
-  const migrationFilename = `${newMigrationNumber}-${kebabCase(migrationName)}.ts`;
+  const migrationFilename = `${migrationFiles.length}-${kebabCase(migrationName)}.ts`;
 
   fs.writeFileSync(
     path.join(MIGRATION_DIR, migrationFilename),


### PR DESCRIPTION
Add an optional `--projects` cli argument for the `migration:run` command.

- The projects argument can take multiple projects, separated by commas `--projects projectOne,projectTwo`
- A projects array can be exported per migration `module.exports.projects = ['projectOne'];`
- Passing the projects argument will filter out any migrations that don't export a matching project name as part of its array.