### PR TITLE
Fix file sorting

### DIFF
--- a/src/cli/run-migration.ts
+++ b/src/cli/run-migration.ts
@@ -44,7 +44,11 @@ const addMigrationHistory = async (client: ClientAPI, filename: string) => {
 const migrate = async (client: ClientAPI, enabledSpaces: string[]) => {
   const history = await getMigrationHistory(client);
   const files = fs.readdirSync(MIGRATION_DIR);
-  const newMigrations = difference(files, history);
+  const newMigrations = difference(files, history).sort((fileA, fileB) => {
+    const a = parseInt(fileA.split('-')[0], 10);
+    const b = parseInt(fileB.split('-')[0], 10);
+    return a - b;
+  });
 
   if (newMigrations.length > 0) {
     console.info('\n📝 Migrating:\n');


### PR DESCRIPTION
Migrations are being run in the "wrong" order because readDirSync returns files in an order like: 0-init, 1-first, 10-tenth, 100-hundredth, 2-second.

So this fix sorts the array manually.